### PR TITLE
README: Mention `vulkano` as the source of `vk-sys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vulkan-bindings
 
 Vulkan bindings for Rust generated from Khronos spec file (vk.xml)
-Macro used to generate commands is inspired by vk-sys package, part of ash.
+Macro used to generate commands is inspired by the `vk-sys` package, part of `vulkano` (until [switching their low-level bindings to `ash`](https://github.com/vulkano-rs/vulkano/issues/1500)).
 
 The bindings are generated directly from vk.xml and therefore up to date with recent
 Vulkan core specification. At this time, only platform independent extensions are emitted.


### PR DESCRIPTION
I don't think `ash` ever had a sys crate, because it itself is the sys crate.
